### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,9 +82,9 @@ services:
     ports:
       - $PATIENT_BROWSER_PORT:80
     command: ["sh", "-c", "
-      envsubst < /usr/share/nginx/html/config/r2.tpl > \/usr/share/nginx/html/config/r2-local.json5 &&
-      envsubst < /usr/share/nginx/html/config/r3.tpl > \/usr/share/nginx/html/config/r3-local.json5 &&
-      envsubst < /usr/share/nginx/html/config/r4.tpl > \/usr/share/nginx/html/config/r4-local.json5 &&
+      envsubst < /usr/share/nginx/html/config/r2.tpl > /usr/share/nginx/html/config/r2-local.json5 &&
+      envsubst < /usr/share/nginx/html/config/r3.tpl > /usr/share/nginx/html/config/r3-local.json5 &&
+      envsubst < /usr/share/nginx/html/config/r4.tpl > /usr/share/nginx/html/config/r4-local.json5 &&
       nginx -g 'daemon off;'"]
     scale: $PATIENT_BROWSER_ENABLED
 


### PR DESCRIPTION
Remove escape characters from nginx envsubst command. Line 85-87 in docker-compose.yml

Resolves 'Found unknown escape character when running docker-compose p #37'